### PR TITLE
Change sidepanel controls

### DIFF
--- a/data.py
+++ b/data.py
@@ -33,6 +33,13 @@ class Spectrum(object):
     def gety(self):
         return self.data[self.specname]
 
+    def __str__(self):
+        return "{}: {}-{} {}".format(
+            self.name,
+            min(self.data[self.freqname]),
+            max(self.data[self.freqname]),
+            self.frequnit
+        )
 
 class DataSource(object):
     '''

--- a/data.py
+++ b/data.py
@@ -99,15 +99,16 @@ class DataSource(object):
         self.trace_counter += 1
         return len(self.traces) - 1 # last index
 
-    def DeleteTrace(self, i):
+    def DeleteTrace(self, target_id):
         '''
-        Delete a trace from the manager
+        Delete a trace from the manager by its ID
         '''
-        if i >= 0 and i < len(self.traces):
-            self.traces.pop(i)
-            return True
-        else:
-            return False
+        for i in range(len(self.traces)):
+            if self.traces[i].id == target_id:
+                self.traces.pop(i)
+                return True
+        
+        return False
     
     def GetTraceByID(self, id):
         '''

--- a/data.py
+++ b/data.py
@@ -26,6 +26,7 @@ class Spectrum(object):
         self.frequnit = frequnit
 
         self.name = name
+        self.is_plotted = False
 
     def getx(self):
         return self.data[self.freqname]

--- a/gui.py
+++ b/gui.py
@@ -74,6 +74,8 @@ class DirTreeCtrl(wx.TreeCtrl):
                  
             for filename in sorted(filenames):
                 self.AppendItem(ids[dirpath], filename, self.fileidx)
+        
+        self.Expand(self.GetRootItem())
 
 class LoadDialog(sized_controls.SizedDialog):
     '''
@@ -211,7 +213,7 @@ class DataTab(SubPanel):
         trace_sizer = wx.BoxSizer(wx.VERTICAL)
 
         # Mixin listctrl for selecting traces
-        self.trace_list = ResizeListCtrl(
+        self.trace_list = wx.ListCtrl(
             trace_pane, size=(-1, 100), style=wx.LC_REPORT
         )
         self.trace_list.InsertColumn(0, 'Name', width=-1)
@@ -320,12 +322,15 @@ class TabPanel(SubPanel):
         nb = wx.Notebook(self.panel)
         # Create tab objects
         tabs = []
+        self.data_tab = DataTab(nb, self.datasrc)
+        tabs.append(self.data_tab.GetPanel())
+
         self.catalog = CatalogTab(nb, self.datasrc)
         tabs.append(self.catalog.GetPanel())
   
         # Names of each tab
-        names = ["Catalog"]
-        # Create notebook object
+        names = ["Data", "Directory"]
+        # Add all tabs to the notebook object
         assert(len(names) == len(tabs))
         for i in range(len(tabs)):
             nb.AddPage(tabs[i], names[i])

--- a/gui.py
+++ b/gui.py
@@ -98,14 +98,23 @@ class DirTreeCtrl(wx.TreeCtrl):
     
     def OnDblClick(self, event):
         act_item = event.GetItem()
-        # If the item is a folder, expand/collapse it. Otherwise, try and read it.
+        # If the item is a folder (has children), expand/collapse it. Otherwise, try and read it.
         if self.GetChildrenCount(act_item) > 0:
             # Expand if collapsed, otherwise collapse
             if self.IsExpanded(act_item): self.Collapse(act_item)
             else: self.Expand(act_item)
         else:
-            abspath = os.path.join(self.dir, self.GetItemText(act_item))
-            # Pass an empty event object
+            # Walk up the tree until the root is reached to get all folders in the path
+            folders = []
+            walker = act_item
+            while walker.IsOk():
+                folders.append(self.GetItemText(walker))
+                walker = self.GetItemParent(walker)
+            
+            abspath = os.path.join(*folders[::-1])
+            
+            print(abspath)
+            # Normally this function takes an event object so we pass None here
             wx.GetTopLevelParent(self).LoadData(None, path=abspath)
 
 class LoadDialog(sized_controls.SizedDialog):

--- a/gui.py
+++ b/gui.py
@@ -35,7 +35,7 @@ class SubPanel():
         Unimplemented functions as a placeholder for custom widgets
         defined by derived classes.
         '''
-        pass
+        raise NotImplementedError("InitUI must be defined for all derived subpanels")
 
     def GetPanel(self):
         '''

--- a/gui.py
+++ b/gui.py
@@ -291,7 +291,7 @@ class DataTab(SubPanel):
                 itemData.is_plotted = False
                 self.tree.SetItemBold(event.GetItem(), bold=False)
             else:
-                # The double clicked item was a spectrum, plot it and make it boldface
+                # Plot it and make it boldface
                 wx.GetTopLevelParent(self.panel).AddTracesToPlot([itemData.id])
                 itemData.is_plotted = True
                 self.tree.SetItemBold(event.GetItem())
@@ -361,6 +361,7 @@ class TextPanel(SubPanel):
 class PlotRegion(SubPanel):
     def __init__(self, parent, datasrc):
         self.plotted_traces = []
+        self.is_blank = True
         super(PlotRegion, self).__init__(parent, datasrc)
 
     def InitUI(self):
@@ -408,7 +409,7 @@ class PlotRegion(SubPanel):
         '''
         Replot all loaded traces.
         '''
-        self.plot_panel.clear()
+        self.is_blank = True
         self.plot_panel.reset_config() # Remove old names of traces
         if len(self.plotted_traces) > 0:
             for id in self.plotted_traces:
@@ -417,13 +418,18 @@ class PlotRegion(SubPanel):
                 assert(spec) # Make sure spectrum is not null
                 self.PlotTrace(spec)
         else:
-            self.plot_panel.unzoom_all() # This call forces the plot to update visually
+            self.plot_panel.clear() # This call forces the plot to update visually
+            self.plot_panel.unzoom_all()
 
     def PlotTrace(self, t, **kwargs):
         '''
         Plot a trace object. Used internally to standardize plotting style.
         '''
-        self.plot_panel.oplot(t.getx(), t.gety(), label=t.name, show_legend=True, **kwargs)
+        if self.is_blank:
+            self.plot_panel.plot(t.getx(), t.gety(), label=t.name, show_legend=True, **kwargs)
+            self.is_blank = False
+        else:
+            self.plot_panel.oplot(t.getx(), t.gety(), label=t.name, show_legend=True, **kwargs)
 
 class Layout(wx.Frame):
 

--- a/gui.py
+++ b/gui.py
@@ -63,6 +63,7 @@ class DirTreeCtrl(wx.TreeCtrl):
         self.setwd(root)
 
     def setwd(self, newdir):
+        self.DeleteAllItems()
         ids = {newdir : self.AddRoot(newdir, self.folderidx)}
         self.SetItemHasChildren(ids[newdir])
  
@@ -164,6 +165,36 @@ class LoadDialog(sized_controls.SizedDialog):
             self.EndModal(event.EventObject.Id)
         else:
             self.Close()
+
+class CatalogTab(SubPanel):
+    '''
+    Implements a window for viewing files in the current working directory
+    and a file selection control for changing the working directory.
+    '''
+    def __init__(self, parent, datasrc):
+        self.cwd = os.getcwd()
+        super(CatalogTab, self).__init__(parent, datasrc)
+
+    def InitUI(self):
+        vsizer = wx.BoxSizer(wx.VERTICAL)
+        
+        # View for files in the current working directory
+        self.tree = DirTreeCtrl(self.panel, datasrc=self.datasrc)
+        vsizer.Add(self.tree, 1, wx.EXPAND)
+
+        # Control for the current working directory
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.dirctrl = wx.DirPickerCtrl(self.panel, path=self.cwd)
+        vsizer.Add(self.dirctrl, 0)
+
+        self.panel.SetSizer(vsizer)
+
+        # Bind a change in the selection to updating the field
+        self.panel.Bind(wx.EVT_DIRPICKER_CHANGED, self.OnDirChanged)
+
+    def OnDirChanged(self, event):
+        newpath = self.dirctrl.GetPath()
+        self.tree.setwd(newpath)
 
 class DataTab(SubPanel):
     '''
@@ -289,8 +320,8 @@ class TabPanel(SubPanel):
         nb = wx.Notebook(self.panel)
         # Create tab objects
         tabs = []
-        self.data_tab = DirTreeCtrl(nb, self.datasrc)
-        tabs.append(self.data_tab)
+        self.catalog = CatalogTab(nb, self.datasrc)
+        tabs.append(self.catalog.GetPanel())
   
         # Names of each tab
         names = ["Catalog"]


### PR DESCRIPTION
- Data tab uses wx.TreeCtrl to show multiple data types (resolves #1)
- Files can be loaded from a window showing the current working directory in the second tab
- Plotting doesn't flash a blank plot for a moment when removing traces